### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile.game-client
+++ b/Dockerfile.game-client
@@ -1,0 +1,27 @@
+FROM node:14
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY client/package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY client/ .
+
+RUN npm run build
+
+# Install http-server to serve the static files
+RUN npm install -g http-server
+
+# Expose port 1234 for the server
+EXPOSE 1234
+
+# Define the command to run the app
+CMD ["http-server", "dist", "-p", "1234"]

--- a/Dockerfile.game-server
+++ b/Dockerfile.game-server
@@ -1,0 +1,23 @@
+FROM node:14
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY server/package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY server/src ./src
+COPY server/tsconfig.json .
+
+RUN npm run build
+
+EXPOSE 2567
+
+CMD [ "npm", "start" ]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO tutorial-phaser
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,102 @@
+namespace: tutorial-phaser
+
+redis:
+  defines: runnable
+  inherits: redis/redis
+  metadata:
+    name: redis
+    description: >-
+      Redis server used for handling presence and session data for the
+      multiplayer game.
+    icon: >-
+      https://cdn.icon-icons.com/icons2/2415/PNG/512/redis_original_wordmark_logo_icon_146369.png
+  variables:
+    redis_disable_commands:
+      type: string
+      value: FLUSHDB,FLUSHALL,CONFIG
+      description: ''
+    redis_empty_password:
+      type: string
+      value: 'yes'
+      description: ''
+    redis_instance_name:
+      type: string
+      value: master
+      description: ''
+    redis_io_thread:
+      type: string
+      value: '1'
+      description: ''
+    redis_io_threads_do_reads:
+      type: string
+      value: 'yes'
+      description: ''
+    redis_port:
+      type: int
+      value: 6379
+      description: ''
+
+game-client:
+  defines: runnable
+  metadata:
+    name: game-client
+    description: >-
+      The client-side of the multiplayer game, built with Phaser and
+      Colyseus.js.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    game-client:
+      image: env-2129.registry.local/game-client:master-8084c30
+      build: .
+      dockerfile: Dockerfile.game-client
+  services:
+    development-server:
+      description: Port for the local development server
+      container: game-client
+      port: 1234
+      host-port: 1234
+      publish: true
+      protocol: tcp
+  connections:
+    game-server-connection:
+      target: tutorial-phaser/game-server
+      service: game-server-port
+      optional: true
+      description: WebSocket connection to the game server
+  variables: {}
+
+game-server:
+  defines: runnable
+  metadata:
+    name: game-server
+    description: >-
+      The server-side WebSocket server for the multiplayer game, using Colyseus
+      and Express.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    game-server:
+      image: env-2129.registry.local/game-server:master-8084c30
+      build: .
+      dockerfile: Dockerfile.game-server
+  services:
+    game-server-port:
+      description: WebSocket server port for the multiplayer game
+      container: game-server
+      port: 2567
+      host-port: 2567
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables:
+    port:
+      env: PORT
+      type: int
+      value: 2567
+      description: The port on which the game server listens for connections
+
+stack:
+  defines: group
+  members:
+    - tutorial-phaser/redis
+    - tutorial-phaser/game-client
+    - tutorial-phaser/game-server


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration

## Changes Made

- **Dockerization**: I have created Dockerfiles for both the game-client and game-server services. The game-client Dockerfile sets up the environment, builds the application using Parcel, and serves it on port 1234 using http-server. The game-server Dockerfile installs dependencies, compiles TypeScript source code, and runs the server on port 2567.
- **Configuration**: Added `monk.yaml` and `MANIFEST` files to define and list Monk configurations for deployment.
- **Service Mapping**: Mapped the services required for the application, including the Redis service which is used by the game-server for handling presence and session data.
- **Redis Integration**: Found and included a MonkHub kit for Redis to ensure the game-server can connect to the Redis service as an external dependency.

## Remaining Work

- **Environment Variables**: The game-server service does not seem to require any specific environment variables except for the known PORT. However, the connection details for Redis are not explicitly defined in the source code or Dockerfile. Further investigation or configuration may be needed to ensure proper connection parameters for Redis.
- **Service Connections**: The game-client service needs its connection to the game-server configured with the correct target port. This should be set to the 'game-server-port' exposed by the game-server service.

## Instructions for Continuation

1. **Redis Connection**: Review the game-server source code or configuration files to determine the exact environment variables or connection parameters for Redis.
2. **Client-Server Connection**: Configure the game-client service to connect to the game-server on the correct target port ('game-server-port').

Once the PR is merged, the application will be re-deployed on each subsequent push, ensuring a smooth CI/CD pipeline for the containerized application.